### PR TITLE
chore: allow memory monitoring

### DIFF
--- a/Dockerfile.cherrypick
+++ b/Dockerfile.cherrypick
@@ -41,6 +41,7 @@ RUN chmod +x /usr/local/bin/tee-server
 COPY ./zkeys /zkeys
 
 LABEL "tee.launch_policy.allow_env_override"="PROJECT_NUMBER,PROJECT_ID,POOL_NAME,SECRET_ID"
+LABEL "tee.launch_policy.monitoring_memory_allow"="always"
 
 COPY update_creds.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/update_creds.sh

--- a/Dockerfile.tee
+++ b/Dockerfile.tee
@@ -49,6 +49,7 @@ RUN chmod +x /usr/local/bin/start.sh
 
 EXPOSE 8888
 LABEL "tee.launch_policy.allow_env_override"="PROJECT_NUMBER,PROJECT_ID,POOL_NAME,SECRET_ID"
+LABEL "tee.launch_policy.monitoring_memory_allow"="always"
 
 WORKDIR /usr/local/bin
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enables TEE memory monitoring via container metadata.
> 
> - Adds `LABEL "tee.launch_policy.monitoring_memory_allow"="always"` to `Dockerfile.cherrypick` and `Dockerfile.tee` alongside existing launch policy labels
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a42a13e685d8601b82da764f3e17ce6bd4b9c2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->