### PR TITLE
ci: update workflow runners to include self-hosted and ubuntu-24-04 (staging)

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -17,7 +17,9 @@ jobs:
       contents: read
       id-token: write
     runs-on:
-      - 'sumsub-runner'
+      - 'self-hosted'
+      - 'selfxyz-org'
+      - 'ubuntu-24-04'
 
     env:
       PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Runner label changes only; main risk is CI builds failing if the new self-hosted runner pool lacks required tools/permissions.
> 
> **Overview**
> Updates the `TEE Docker Build` GitHub Actions workflow (`artifacts.yml`) to run the `prod` job on a different self-hosted runner configuration by replacing the old runner label with the `self-hosted`/`selfxyz-org`/`ubuntu-24-04` label set.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c6b42cc4bc118e6ece5224bbb898764b9a93194. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->