### PR TITLE
ci: update workflow runners to include self-hosted and ubuntu-24-04 (main)

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -17,7 +17,9 @@ jobs:
       contents: read
       id-token: write
     runs-on:
-      - 'sumsub-runner'
+      - 'self-hosted'
+      - 'selfxyz-org'
+      - 'ubuntu-24-04'
 
     env:
       PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Runner label/OS selection change only; main risk is CI failures if the new self-hosted runner pool lacks required tooling or permissions.
> 
> **Overview**
> Updates the `artifacts.yml` workflow to run the `prod` job on a self-hosted runner labeled `selfxyz-org` targeting `ubuntu-24-04`, replacing the previous `sumsub-runner` label.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c6b42cc4bc118e6ece5224bbb898764b9a93194. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->